### PR TITLE
fix: Escape sequences & related queries

### DIFF
--- a/editor_queries/helix/highlights.scm
+++ b/editor_queries/helix/highlights.scm
@@ -135,6 +135,11 @@
 (constant
   name: (identifier) @constant)
 
+; constant.character.escape
+; -------------------------
+
+(escape_sequence) @constant.character.escape
+
 ; constant.numeric.integer
 ; ------------------------
 

--- a/editor_queries/neovim/highlights.scm
+++ b/editor_queries/neovim/highlights.scm
@@ -99,6 +99,11 @@
 
 (string) @string
 
+; string.escape
+; -------------
+
+(escape_sequence) @string.escape
+
 ; string.special.path
 ; -------------------
 

--- a/grammar.js
+++ b/grammar.js
@@ -649,10 +649,10 @@ module.exports = grammar({
     escape_sequence: () => token.immediate(seq(
       '\\',
       choice(
-        /[^xu]/,                 // anything, except for [xu], which are:
-        /x[0-9a-fA-F]{2}/,       // \x00 through \xFF
-        /u[0-9a-fA-F]{4}/,       // \u0000 through \uFFFF
-        /u\{[0-9a-fA-F]{1,6}\}/, // \u{0} through \u{FFFFFF}
+        /[\\"nrtvbf]/,           // \\ \" \n \r \t \v \b \f
+        /x[0-9a-fA-F]{2}/,       // hexEscape, \x00 through \xFF
+        /u[0-9a-fA-F]{4}/,       // unicodeEscape, \u0000 through \uFFFF
+        /u\{[0-9a-fA-F]{1,6}\}/, // unicodeCodePoint, \u{0} through \u{FFFFFF}
       ),
     )),
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "src/**"
   ],
   "scripts": {
+    "ts": "tree-sitter",
     "gen": "tree-sitter generate",
     "test": "tree-sitter test",
     "gentest": "tree-sitter generate && tree-sitter test",

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -99,11 +99,13 @@
 
 (string) @string
 
-; string.special.path
-; -------------------
+; string.special
+; --------------
 
 (import_statement
-  library: (string) @string.special.path)
+  library: (string) @string.special)
+
+(escape_sequence) @string.special
 
 ; constant
 ; --------
@@ -169,7 +171,7 @@
 ; --------
 
 (function
-  name: (identifier) @function.method)
+  name: (identifier) @function)
 
 (native_function
   name: (identifier) @function)
@@ -181,24 +183,21 @@
   name: (identifier) @function)
 
 (init_function
-  "init" @function.method)
+  "init" @function)
 
 (receive_function
-  "receive" @function.method)
+  "receive" @function)
 
 (bounced_function
-  "bounced" @function.method)
+  "bounced" @function)
 
 (external_function
-  "external" @function.method)
+  "external" @function)
 
 (func_identifier) @function
 
-; function.method
-; ---------------
-
 (method_call_expression
-  name: (identifier) @function.method)
+  name: (identifier) @function)
 
 ; function.builtin
 ; ----------------

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2962,7 +2962,7 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[^xu]"
+                "value": "[\\\\\"nrtvbf]"
               },
               {
                 "type": "PATTERN",

--- a/src/parser.c
+++ b/src/parser.c
@@ -2099,7 +2099,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 22:
       if (lookahead == 'u') ADVANCE(23);
       if (lookahead == 'x') ADVANCE(37);
-      if (lookahead != 0) ADVANCE(96);
+      if (lookahead == '"' ||
+          lookahead == '\\' ||
+          lookahead == 'b' ||
+          lookahead == 'f' ||
+          lookahead == 'n' ||
+          lookahead == 'r' ||
+          ('t' <= lookahead && lookahead <= 'v')) ADVANCE(96);
       END_STATE();
     case 23:
       if (lookahead == '{') ADVANCE(35);

--- a/test/highlight/contract.tact
+++ b/test/highlight/contract.tact
@@ -6,20 +6,20 @@ contract Empty {}
 
 contract Filled {
  init() {}
- // <- function.method
+ // <- function
  //  ^ punctuation.bracket
  //   ^ punctuation.bracket
  //     ^ punctuation.bracket
  //      ^ punctuation.bracket
 
  receive() {}
- // <- function.method
+ // <- function
 
  external() {}
- // <- function.method
+ // <- function
 
  bounced(msg: Slice) {}
- // <- function.method
+ // <- function
  //      ^ variable.parameter
  //         ^ punctuation.delimiter
  //           ^ type.builtin

--- a/test/highlight/import.tact
+++ b/test/highlight/import.tact
@@ -1,6 +1,6 @@
 import "@stdlib/deploy";
 // <- keyword
-//     ^ string.special.path
+//     ^ string.special
 //                     ^ punctuation.delimiter
 
 // comment

--- a/test/highlight/trait.tact
+++ b/test/highlight/trait.tact
@@ -33,7 +33,7 @@ trait Filled with Deployable, Ownable {
   get fun c(arg1: String): Int {
   // <- keyword
   //  ^ keyword
-  //      ^ function.method
+  //      ^ function
   //       ^ punctuation.bracket
   //        ^ variable.parameter
   //            ^ punctuation.delimiter
@@ -64,7 +64,7 @@ trait Filled with Deployable, Ownable {
   //       ^ keyword
   //              ^ keyword
   //                       ^ keyword
-  //                           ^ function.method
+  //                           ^ function
   //                            ^ punctuation.bracket
   //                             ^ punctuation.bracket
   //                               ^ punctuation.bracket

--- a/test/highlight/value_expression.tact
+++ b/test/highlight/value_expression.tact
@@ -7,7 +7,7 @@ extends fun c(self: Int) {
 
     /* call_expression */
     95.toString();
-    // ^ function.method
+    // ^ function
 
     /* field_expression */
     context().sender;
@@ -71,11 +71,12 @@ extends fun c(self: Int) {
     //     ^ constructor
 
     /* string */
-    "Tact is awesome!";
+    "// \\ \" \n\r \t\v \b\f \u{0} \u{FFFFFF} \u0000 \xFF";
     // <- string
+    //  ^ string.special
 
     /* self, not as a builtin, but as a parameter */
     self.toString();
     // <- variable.parameter
-    //   ^ function.method
+    //   ^ function
 }


### PR DESCRIPTION
This is a follow-up to: #17, which:
* Makes all Tree-sitter highlighting queries conformant to the highlighting spec
* Adds highlighting of escape sequences to Neovim and Helix queries
* Narrows the possible options of escape sequences to match Ohm's grammar of Tact (i.e. there are now only a few options of escape sequences and all illegal options would visually error)